### PR TITLE
random text and number

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -199,6 +199,57 @@ data class InputTextCommand(
     }
 }
 
+data class InputTextRandomCommand(
+    val inputType: String? = "text",
+    val length: Int? = 8,
+) : Command {
+
+    fun genRamdomString() : String {
+        val finalType = when(inputType) {
+            "number" -> "number"
+            "text" -> "text"
+            else -> "text"
+        }
+        val lengthNonNull = length ?: 8
+        val finalLength = if (lengthNonNull <= ) 8 else lengthNonNull
+
+        if (finalType == "number") return getRandomNumber(finalLength)
+
+        return getRandomText(finalLength)
+    }
+
+    private fun getRandomNumber(length: Int): String {
+        val charset = "0123456789"
+        val charsetWithoutZero = "123456789"
+        val randomNum = (1..length)
+            .map { charset.random() }
+            .joinToString("")
+        return if (randomNum.startsWith("0")) {
+            charsetWithoutZero.random() + randomNum.substring(1)
+        } else randomNum
+
+    }
+
+    private fun getRandomText(length: Int): String {
+        val charset = "ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz0123456789"
+        return (1..length)
+            .map { charset.random() }
+            .joinToString("")
+    }
+
+    override fun description(): String {
+        return "Input text random $inputType with length $length"
+    }
+
+    override fun injectEnv(env: Map<String, String>): InputTextRandomCommand {
+        return copy(
+            inputType = inputType?.injectEnv(env),
+            length = length?.injectEnv(env)
+        )
+    }
+}
+
+
 data class LaunchAppCommand(
     val appId: String,
     val clearState: Boolean? = null,

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
@@ -33,6 +33,7 @@ data class MaestroCommand(
     val backPressCommand: BackPressCommand? = null,
     val assertCommand: AssertCommand? = null,
     val inputTextCommand: InputTextCommand? = null,
+    val inputTextRandomCommand: InputTextRandomCommand? = null,
     val launchAppCommand: LaunchAppCommand? = null,
     val applyConfigurationCommand: ApplyConfigurationCommand? = null,
     val openLinkCommand: OpenLinkCommand? = null,
@@ -53,6 +54,7 @@ data class MaestroCommand(
         backPressCommand = command as? BackPressCommand,
         assertCommand = command as? AssertCommand,
         inputTextCommand = command as? InputTextCommand,
+        inputTextRandomCommand = command as? InputTextRandomCommand,
         launchAppCommand = command as? LaunchAppCommand,
         applyConfigurationCommand = command as? ApplyConfigurationCommand,
         openLinkCommand = command as? OpenLinkCommand,
@@ -73,6 +75,7 @@ data class MaestroCommand(
         backPressCommand != null -> backPressCommand
         assertCommand != null -> assertCommand
         inputTextCommand != null -> inputTextCommand
+        inputTextRandomCommand != null -> inputTextRandomCommand
         launchAppCommand != null -> launchAppCommand
         applyConfigurationCommand != null -> applyConfigurationCommand
         openLinkCommand != null -> openLinkCommand

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -127,6 +127,7 @@ class Orchestra(
             is SwipeCommand -> swipeCommand(command)
             is AssertCommand -> assertCommand(command)
             is InputTextCommand -> inputTextCommand(command)
+            is InputTextRandomCommand -> inputTextRandomCommand(command)
             is LaunchAppCommand -> launchAppCommand(command)
             is OpenLinkCommand -> openLinkCommand(command)
             is PressKeyCommand -> pressKeyCommand(command)
@@ -191,6 +192,10 @@ class Orchestra(
         }
 
         maestro.inputText(command.text)
+    }
+
+    private fun inputTextRandomCommand(command: InputTextRandomCommand) {
+        inputTextCommand(InputTextCommand(command.genRamdomString()))
     }
 
     private fun assertCommand(command: AssertCommand) {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -30,6 +30,7 @@ import maestro.orchestra.ElementTrait
 import maestro.orchestra.EraseTextCommand
 import maestro.orchestra.HideKeyboardCommand
 import maestro.orchestra.InputTextCommand
+import maestro.orchestra.InputTextRandomCommand
 import maestro.orchestra.LaunchAppCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.OpenLinkCommand
@@ -54,6 +55,7 @@ data class YamlFluentCommand(
     val assertNotVisible: YamlElementSelectorUnion? = null,
     val action: String? = null,
     val inputText: String? = null,
+    val inputTextRandom: YamlInputTextRandom? = null,
     val launchApp: YamlLaunchApp? = null,
     val swipe: YamlElementSelectorUnion? = null,
     val openLink: String? = null,
@@ -75,6 +77,7 @@ data class YamlFluentCommand(
             assertVisible != null -> listOf(MaestroCommand(AssertCommand(visible = toElementSelector(assertVisible))))
             assertNotVisible != null -> listOf(MaestroCommand(AssertCommand(notVisible = toElementSelector(assertNotVisible))))
             inputText != null -> listOf(MaestroCommand(InputTextCommand(inputText)))
+            inputTextRandom != null -> listOf(inputTextRandom(inputTextRandom))
             swipe != null -> listOf(swipeCommand(swipe))
             openLink != null -> listOf(MaestroCommand(OpenLinkCommand(openLink)))
             pressKey != null -> listOf(MaestroCommand(PressKeyCommand(code = KeyCode.getByName(pressKey) ?: throw SyntaxError("Unknown key name: $pressKey"))))
@@ -167,6 +170,13 @@ data class YamlFluentCommand(
                 clearKeychain = command.clearKeychain,
             )
         )
+    }
+
+    private fun inputTextRandom(command: YamlInputTextRandom): MaestroCommand {
+        return MaestroCommand(InputTextRandomCommand(
+            inputType = command.inputType,
+            length = command.length,
+        ),)
     }
 
     private fun tapCommand(
@@ -346,6 +356,10 @@ data class YamlFluentCommand(
 
                 "scroll" -> YamlFluentCommand(
                     action = "scroll"
+                )
+
+                "inputTextRandom" -> YamlFluentCommand(
+                    inputTextRandom = YamlInputTextRandom(inputType = "text", length = 8,)
                 )
 
                 else -> throw SyntaxError("Invalid command: \"$stringCommand\"")

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlnputTextRandom.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlnputTextRandom.kt
@@ -1,0 +1,41 @@
+/*
+ *
+ *  Copyright (c) 2022 mobile.dev inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package maestro.orchestra.yaml
+
+import com.fasterxml.jackson.annotation.JsonCreator
+
+data class YamlInputTextRandom(
+    // specify the input method type: text (default), number, textCapCharacters phone, textCapWords, textMultiLine, textImeMultiLine, ... 
+    val inputType: String?,
+    // length of random text, default 8
+    val length: Int?,
+) {
+    companion object {
+
+        @JvmStatic
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        fun parse(type: String): YamlInputTextRandom {
+            return YamlInputTextRandom(
+                inputType = type,
+                length = 8,
+            )
+        }
+    }
+}

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -231,6 +231,33 @@ internal class MaestroCommandSerializationTest {
     }
 
     @Test
+    fun `serialize InputTextRandomCommand`() {
+        // given
+        val command = MaestroCommand(
+          InputTextRandomCommand("number", 8)
+        )
+
+        // when
+        val serializedCommandJson = command.toJson()
+        val deserializedCommand = objectMapper.readValue(serializedCommandJson, MaestroCommand::class.java)
+
+        // then
+        @Language("json")
+        val expectedJson = """
+            {
+              "inputTextRandomCommand" : {
+                "inputType" : "number",
+                "lenght" : 8
+              }
+            }
+          """.trimIndent()
+        assertThat(serializedCommandJson)
+            .isEqualTo(expectedJson)
+        assertThat(deserializedCommand)
+            .isEqualTo(command)
+    }
+
+    @Test
     fun `serialize LaunchAppCommand`() {
         // given
         val command = MaestroCommand(


### PR DESCRIPTION
## Proposed Changes
add random text by command `inputTextRandom` included 
- `inputType`: specify the input method type: node (default), text , number, textCapCharacters phone, textCapWords, textMultiLine, textImeMultiLine, ...
- `length`: length of random text 


```
- inputTextRandom: # This command will add text as number with length is 2, 10 <= number <= 99
      inputType: "number"
      length: 2
```


```
- inputTextRandom: # This command will add  random text with length is 3, as Abc, ads, asd, .... 
      inputType: "text"
      length: 3
```


## Testing
<!--- Please describe how you tested your changes. -->

## Issues Fixed